### PR TITLE
Travis CI: downgrade to Oracle JDK 8u11 to avoid JDK-8065315

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,14 @@
 language: java
-jdk:
-- oraclejdk8
+jdk: oraclejdk8
+
+# As a workaround to JDK-8065315 bug, let's downgrade Oracle JDK 8
+# until Travis VM image provides again a sane JDK version.
+# see also http://stackoverflow.com/questions/27047496/javac-1-8-0-25-has-known-bug-how-to-use-different-version
+before_install:
+  - wget https://launchpad.net/~webupd8team/+archive/ubuntu/java/+files/oracle-java8-installer_8u11%2B8u6arm-1~webupd8~3_all.deb -O oracle-java8-installer.deb
+  - sudo dpkg -i oracle-java8-installer.deb
+  - java -version
+
 deploy:
   provider: releases
   api_key:


### PR DESCRIPTION
@tbsalling This pull request is related to your [question on StackOverflow](http://stackoverflow.com/questions/27047496/javac-1-8-0-25-has-known-bug-how-to-use-different-version).

This is a (temporary) workaround to avoid JDK-8065315 bug until Travis VM image provides again a sane Oracle JDK 8 version.

Note that this trick could be improved by checking which `java -version` is currently installed on the Travis VM, and only downgrade when needed.
