### PR TITLE
Decoding of pseudo-valid AIS messages in the wild / AIS type 24 with 158 bits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,6 @@
 language: java
-jdk: oraclejdk8
-
-# As a workaround to JDK-8065315 bug, let's downgrade Oracle JDK 8
-# until Travis VM image provides again a sane JDK version.
-# see also http://stackoverflow.com/questions/27047496/javac-1-8-0-25-has-known-bug-how-to-use-different-version
-before_install:
-  - wget https://launchpad.net/~webupd8team/+archive/ubuntu/java/+files/oracle-java8-installer_8u11%2B8u6arm-1~webupd8~3_all.deb -O oracle-java8-installer.deb
-  - sudo dpkg -i oracle-java8-installer.deb
-  - java -version
-
+jdk:
+- oraclejdk8
 deploy:
   provider: releases
   api_key:

--- a/src/main/java/dk/tbsalling/aismessages/ais/messages/AISMessage.java
+++ b/src/main/java/dk/tbsalling/aismessages/ais/messages/AISMessage.java
@@ -220,9 +220,21 @@ public abstract class AISMessage implements Serializable, CachedDecodedValues {
         }
         return b;
     }
+    
+    protected String getZeroBitStuffedString(Integer endIndex) {
+        String b = getBitString();
+		if (b.length()-endIndex < 0){
+	        StringBuffer c = new StringBuffer(b);
+			for (int i = b.length()-endIndex; i < 0; i++) {
+				c  = c.append("0");
+			}
+			b = c.toString();
+		}
+        return b;
+    }
 
     protected String getBits(Integer beginIndex, Integer endIndex) {
-        return getBitString().substring(beginIndex, endIndex);
+        return getZeroBitStuffedString(endIndex).substring(beginIndex, endIndex);
     }
 
     protected int getNumberOfBits() {	
@@ -496,7 +508,7 @@ public abstract class AISMessage implements Serializable, CachedDecodedValues {
                 }
                 break;
             case 24:
-                if (actualMessageLength != 160 && actualMessageLength != 168) {
+                if (actualMessageLength != 160 && actualMessageLength != 168 && actualMessageLength != 158 ) {
                     LOG.warning("Message type 24: Illegal message length: " + bitString.length() + " bits.");
                     return Boolean.FALSE;
                 }

--- a/src/main/java/dk/tbsalling/aismessages/ais/messages/AISMessage.java
+++ b/src/main/java/dk/tbsalling/aismessages/ais/messages/AISMessage.java
@@ -400,7 +400,7 @@ public abstract class AISMessage implements Serializable, CachedDecodedValues {
                 if (actualMessageLength != 168) return Boolean.FALSE;
                 break;
             case 5:
-                if (actualMessageLength != 424) {
+                if (actualMessageLength != 424 && actualMessageLength != 422) {
                     LOG.warning("Message type 5: Illegal message length: " + bitString.length() + " bits.");
                     return Boolean.FALSE;
                 }

--- a/src/main/java/dk/tbsalling/aismessages/ais/messages/ShipAndVoyageData.java
+++ b/src/main/java/dk/tbsalling/aismessages/ais/messages/ShipAndVoyageData.java
@@ -57,7 +57,7 @@ public class ShipAndVoyageData extends AISMessage implements StaticDataReport {
             throw new UnsupportedMessageType(messageType.getCode());
         }
         final int numberOfBits = getNumberOfBits();
-        if (numberOfBits != 424) {
+        if (numberOfBits != 424 && numberOfBits != 422) {
             throw new InvalidMessage("Message of type " + messageType + " expected to be 424 bits long; not " + numberOfBits);
         }
     }


### PR DESCRIPTION
Hi Thomas, 

I've observed many instances of class B static messages that are made up for only 158 bits. I want to decode these messages because they are transmitting their ship names but just not according to ?spec?. My changes  affect the getBits method in AISMessage which may too general but will only affect the decoding of pseudo-valid length messages anyway. Another solution is to override it in ClassBCSStaticDataReport. If you are interested, I would be happy to do that. 

Cheers, 

Yipeng