### PR TITLE
Travis CI: Force to upgrade WebUpd8 jdk8 package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: java
 jdk:
-- oraclejdk8
+  - oraclejdk8
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install --only-upgrade -y oracle-java8-installer
+  - java -version
 deploy:
   provider: releases
   api_key:


### PR DESCRIPTION
In follow up of http://stackoverflow.com/questions/27047496/javac-1-8-0-25-has-known-bug-how-to-use-different-version/27056138?noredirect=1#comment47183991_27056138:

[Webupd8 PPA](https://launchpad.net/~webupd8team/+archive/ubuntu/java) now provides `1.8.0_40-b25`, and with the propose change to your `.travis.yml`, you'll always build with the latest package released by Webupd8 team (regardless of the Travis VM image state).
(Note that there is also very good chances that this Java version will also be present on the [upcoming Travis VM images](http://docs.travis-ci.com/user/build-environment-updates/2015-04-09/) announced for tomorrow.)

But **quite unfortunately** this PR doesn't really help, because Travis integration is now failing with a new [java compilation error](https://travis-ci.org/gildegoma/aismessages/builds/57789928#L967-L968) (different error message in comparison to previous [JDK-8065315 - javac throws NPE](https://bugs.openjdk.java.net/browse/JDK-8065315), which should fixed). I can reproduce the same error on my local machine (OSX with java 1.8.0_40-b25) and after a very quick search, it seems that https://bugs.openjdk.java.net/browse/JDK-8068399 might be relevant. I do hope you can find a workaround in your own codebase (BTW: kudos to hit two JDK bugs in a row ;-)

All that said, I see in this new integration problem a real need to have a stable way to select former JDK versions, and it is quite sad that the Webupd8 PPA does not provide a complete archive... 
At the moment, I don't have any easy alternatives to propose ([openjdk-r PPA](https://launchpad.net/~openjdk-r/+archive/ubuntu/ppa/+packages?field.name_filter=openjdk-8&field.status_filter=superseded&field.series_filter=trusty) is even more incomplete). Hosting [own-made packages](http://www.oracle.com/technetwork/java/javase/downloads/java-archive-javase8-2177648.html) is not straightforward, but doable though (either [from tarball](https://jerrylu.name/2014/08/23/installing-jdk-8-on-debian-wheezy/) or by [converting the Oracle RPM package](https://help.ubuntu.com/community/RPM/AlienHowto) with alien tool).

Feel free to close this "informative" pull request and good luck! I'll keep you informed if I have any news about JDK minor version selection...