### PR TITLE
bitstring Integer sign parsing.

### DIFF
--- a/src/main/java/dk/tbsalling/aismessages/ais/Decoders.java
+++ b/src/main/java/dk/tbsalling/aismessages/ais/Decoders.java
@@ -34,7 +34,7 @@ public class Decoders {
                 valueBits = valueBits.replaceAll("0", "x");
                 valueBits = valueBits.replaceAll("1", "0");
                 valueBits = valueBits.replaceAll("x", "1");
-                value = UNSIGNED_INTEGER_DECODER.apply("-" + valueBits);
+                value = -1 - UNSIGNED_INTEGER_DECODER.apply(valueBits);
             }
             return value;
         }
@@ -44,7 +44,7 @@ public class Decoders {
 
     public static final Function<String, Boolean> BOOLEAN_DECODER = bitString -> "1".equals(bitString.substring(0, 1));
 
-    public static final Function<String, Integer> UNSIGNED_INTEGER_DECODER = bitString -> Integer.parseInt(bitString, 2);
+    public static final Function<String, Integer> UNSIGNED_INTEGER_DECODER = bitString -> Integer.parseUnsignedInt(bitString, 2);
 
     public static final Function<String, Long> UNSIGNED_LONG_DECODER = bitString -> Long.parseLong(bitString, 2);
 

--- a/src/main/java/dk/tbsalling/aismessages/ais/messages/types/ITDMACommunicationState.java
+++ b/src/main/java/dk/tbsalling/aismessages/ais/messages/types/ITDMACommunicationState.java
@@ -19,7 +19,7 @@ package dk.tbsalling.aismessages.ais.messages.types;
 import java.io.Serializable;
 
 import static dk.tbsalling.aismessages.ais.Decoders.BOOLEAN_DECODER;
-import static dk.tbsalling.aismessages.ais.Decoders.INTEGER_DECODER;
+import static dk.tbsalling.aismessages.ais.Decoders.UNSIGNED_INTEGER_DECODER;
 import static java.util.Objects.requireNonNull;
 
 public class ITDMACommunicationState extends CommunicationState implements Serializable {
@@ -39,9 +39,9 @@ public class ITDMACommunicationState extends CommunicationState implements Seria
 			return null;
 
 		return new ITDMACommunicationState(
-			SyncState.fromInteger(INTEGER_DECODER.apply(bitString.substring(0, 2))),
-			INTEGER_DECODER.apply(bitString.substring(2, 15)),
-			INTEGER_DECODER.apply(bitString.substring(15, 18)),
+			SyncState.fromInteger(UNSIGNED_INTEGER_DECODER.apply(bitString.substring(0, 2))),
+			UNSIGNED_INTEGER_DECODER.apply(bitString.substring(2, 15)),
+			UNSIGNED_INTEGER_DECODER.apply(bitString.substring(15, 18)),
 			BOOLEAN_DECODER.apply(bitString.substring(18, 19))
 		);
 	}

--- a/src/main/java/dk/tbsalling/aismessages/ais/messages/types/SOTDMACommunicationState.java
+++ b/src/main/java/dk/tbsalling/aismessages/ais/messages/types/SOTDMACommunicationState.java
@@ -19,7 +19,7 @@ package dk.tbsalling.aismessages.ais.messages.types;
 import java.io.Serializable;
 import java.util.logging.Logger;
 
-import static dk.tbsalling.aismessages.ais.Decoders.INTEGER_DECODER;
+import static dk.tbsalling.aismessages.ais.Decoders.UNSIGNED_INTEGER_DECODER;
 import static java.util.Objects.requireNonNull;
 
 public class SOTDMACommunicationState extends CommunicationState implements Serializable {
@@ -43,27 +43,27 @@ public class SOTDMACommunicationState extends CommunicationState implements Seri
 		if (bitString.length() != 19 || !bitString.matches("(0|1)*"))
 			return null;
 
-		SyncState syncState = SyncState.fromInteger(INTEGER_DECODER.apply(bitString.substring(0, 2)));
-		final int slotTimeout = INTEGER_DECODER.apply(bitString.substring(2, 5));
+		SyncState syncState = SyncState.fromInteger(UNSIGNED_INTEGER_DECODER.apply(bitString.substring(0, 2)));
+		final int slotTimeout = UNSIGNED_INTEGER_DECODER.apply(bitString.substring(2, 5));
 		Integer numberOfReceivedStations=null, slotNumber=null, utcHour=null, utcMinute=null, slotOffset=null;
 
 		if (slotTimeout == 3 || slotTimeout == 5 || slotTimeout == 7) {
-			numberOfReceivedStations = INTEGER_DECODER.apply(bitString.substring(5, 19));
-			if (numberOfReceivedStations < 0 || numberOfReceivedStations > 16383)
+			numberOfReceivedStations = UNSIGNED_INTEGER_DECODER.apply(bitString.substring(5, 19));
+			if (numberOfReceivedStations > 16383)
 				LOG.warning("numberOfReceivedStations: " + numberOfReceivedStations + ": Out of range.");
 		} else if (slotTimeout == 2 || slotTimeout == 4 || slotTimeout == 6) {
-			slotNumber = INTEGER_DECODER.apply(bitString.substring(5, 19));
-			if (slotNumber < 0 || slotNumber > 2249)
+			slotNumber = UNSIGNED_INTEGER_DECODER.apply(bitString.substring(5, 19));
+			if (slotNumber > 2249)
 				LOG.warning("slotNumber: " + slotNumber + ": Out of range.");
 		}  else if (slotTimeout == 1) {
-			utcHour = INTEGER_DECODER.apply(bitString.substring(5, 10));
-			if (utcHour < 0 || utcHour > 23)
+			utcHour = UNSIGNED_INTEGER_DECODER.apply(bitString.substring(5, 10));
+			if (utcHour > 23)
 				LOG.warning("utcHour: " + utcHour + ": Out of range.");
-			utcMinute = INTEGER_DECODER.apply(bitString.substring(10, 17));
-			if (utcMinute < 0 || utcMinute > 59)
+			utcMinute = UNSIGNED_INTEGER_DECODER.apply(bitString.substring(10, 17));
+			if (utcMinute > 59)
 				LOG.warning("utcMinute: " + utcMinute + ": Out of range.");
 		}  else if (slotTimeout == 0) {
-			slotOffset = INTEGER_DECODER.apply(bitString.substring(5, 19));
+			slotOffset = UNSIGNED_INTEGER_DECODER.apply(bitString.substring(5, 19));
 		}
 
 		return new SOTDMACommunicationState(syncState, slotTimeout, numberOfReceivedStations, slotNumber, utcHour, utcMinute, slotOffset);

--- a/src/test/java/dk/tbsalling/aismessages/ais/DecodersTest.java
+++ b/src/test/java/dk/tbsalling/aismessages/ais/DecodersTest.java
@@ -20,7 +20,7 @@ public class DecodersTest {
 
         assertEquals(Float.valueOf(0), FLOAT_DECODER.apply("0000000000000000000000000000"));
         assertEquals(Float.valueOf(1), FLOAT_DECODER.apply("0000000000000000000000000001"));
-        assertEquals(Float.valueOf(0), FLOAT_DECODER.apply("1111111111111111111111111111"));
+        assertEquals(Float.valueOf(-1), FLOAT_DECODER.apply("1111111111111111111111111111"));
         assertEquals(-123.450533333333f, FLOAT_DECODER.apply("1011100101011100011011001111") / 600000f, 1e-16);// 74070320
         assertEquals(37.21113f,          FLOAT_DECODER.apply("001010101001010110110010100") / 600000f, 1e-16);
         // 181 degrees (0x6791AC0 hex)


### PR DESCRIPTION
Apply two's complement for INTEGER_DECODER.

Changes from INTEGER_DECODER to UNSIGNED_INTEGER_DECODER have to be checked as I'm not an expert on NMEA/AIS messages.