### PR TITLE
Stop AISInputStreamReader on requestStop

### DIFF
--- a/src/main/java/dk/tbsalling/aismessages/AISInputStreamReader.java
+++ b/src/main/java/dk/tbsalling/aismessages/AISInputStreamReader.java
@@ -40,19 +40,18 @@ public class AISInputStreamReader {
         this.nmeaMessageInputStreamReader = new NMEAMessageInputStreamReader(inputStream, this.nmeaMessageHandler::accept);
 	}
 
-	public final synchronized void requestStop() {
-		this.stopRequested = true;
+	public final void requestStop() {
+		this.nmeaMessageInputStreamReader.requestStop();
 	}
 
-    public final synchronized boolean isStopRequested() {
-        return stopRequested;
+    public final boolean isStopRequested() {
+        return this.nmeaMessageInputStreamReader.isStopRequested();
     }
 
     public void run() throws IOException {
         this.nmeaMessageInputStreamReader.run();
 	}
 
-	private boolean stopRequested = false;
     private final NMEAMessageHandler nmeaMessageHandler;
 	private final NMEAMessageInputStreamReader nmeaMessageInputStreamReader;
 }


### PR DESCRIPTION
I was trying out your library, but noticed that the InputStream reader does not actually stop when a stop is requested. The variable that is set to true is not read by the `NMEAMessageInputStreamReader`.

This PR fixes that, and also replaced synchronization on the whole object with a single `AtomicBoolean`