### PR TITLE
Add methods to retrieve raw AIS values for floating-point fields

### DIFF
--- a/src/main/java/dk/tbsalling/aismessages/ais/messages/DynamicDataReport.java
+++ b/src/main/java/dk/tbsalling/aismessages/ais/messages/DynamicDataReport.java
@@ -21,7 +21,11 @@ package dk.tbsalling.aismessages.ais.messages;
 
 public interface DynamicDataReport extends DataReport {
 	Float getLatitude();
+	Integer getRawLatitude();
 	Float getLongitude();
+	Integer getRawLongitude();
 	Float getSpeedOverGround();
+	Integer getRawSpeedOverGround();
 	Float getCourseOverGround();
+	Integer getRawCourseOverGround();
 }

--- a/src/main/java/dk/tbsalling/aismessages/ais/messages/ExtendedClassBEquipmentPositionReport.java
+++ b/src/main/java/dk/tbsalling/aismessages/ais/messages/ExtendedClassBEquipmentPositionReport.java
@@ -28,6 +28,7 @@ import static dk.tbsalling.aismessages.ais.Decoders.FLOAT_DECODER;
 import static dk.tbsalling.aismessages.ais.Decoders.STRING_DECODER;
 import static dk.tbsalling.aismessages.ais.Decoders.UNSIGNED_FLOAT_DECODER;
 import static dk.tbsalling.aismessages.ais.Decoders.UNSIGNED_INTEGER_DECODER;
+import static dk.tbsalling.aismessages.ais.Decoders.INTEGER_DECODER;
 
 @SuppressWarnings("serial")
 public class ExtendedClassBEquipmentPositionReport extends AISMessage implements ExtendedDynamicDataReport {
@@ -63,6 +64,11 @@ public class ExtendedClassBEquipmentPositionReport extends AISMessage implements
 	}
 
     @SuppressWarnings("unused")
+    public Integer getRawSpeedOverGround() {
+        return UNSIGNED_INTEGER_DECODER.apply(getBits(46, 55));
+    }
+
+    @SuppressWarnings("unused")
 	public Boolean getPositionAccurate() {
         return getDecodedValue(() -> positionAccurate, value -> positionAccurate = value, () -> Boolean.TRUE, () -> BOOLEAN_DECODER.apply(getBits(56, 57)));
 	}
@@ -73,14 +79,29 @@ public class ExtendedClassBEquipmentPositionReport extends AISMessage implements
 	}
 
     @SuppressWarnings("unused")
+    public Integer getRawLatitude() {
+        return INTEGER_DECODER.apply(getBits(85, 112));
+    }
+
+    @SuppressWarnings("unused")
 	public Float getLongitude() {
         return getDecodedValue(() -> longitude, value -> longitude = value, () -> Boolean.TRUE, () -> FLOAT_DECODER.apply(getBits(57, 85)) / 600000f);
 	}
 
     @SuppressWarnings("unused")
+    public Integer getRawLongitude() {
+        return INTEGER_DECODER.apply(getBits(57, 85));
+    }
+
+    @SuppressWarnings("unused")
 	public Float getCourseOverGround() {
         return getDecodedValue(() -> courseOverGround, value -> courseOverGround = value, () -> Boolean.TRUE, () -> UNSIGNED_FLOAT_DECODER.apply(getBits(112, 124)) / 10f);
 	}
+
+    @SuppressWarnings("unused")
+    public Integer getRawCourseOverGround() {
+        return UNSIGNED_INTEGER_DECODER.apply(getBits(112, 124));
+    }
 
     @SuppressWarnings("unused")
 	public Integer getTrueHeading() {

--- a/src/main/java/dk/tbsalling/aismessages/ais/messages/LongRangeBroadcastMessage.java
+++ b/src/main/java/dk/tbsalling/aismessages/ais/messages/LongRangeBroadcastMessage.java
@@ -8,6 +8,7 @@ import dk.tbsalling.aismessages.nmea.messages.NMEAMessage;
 import static dk.tbsalling.aismessages.ais.Decoders.BOOLEAN_DECODER;
 import static dk.tbsalling.aismessages.ais.Decoders.FLOAT_DECODER;
 import static dk.tbsalling.aismessages.ais.Decoders.UNSIGNED_INTEGER_DECODER;
+import static dk.tbsalling.aismessages.ais.Decoders.INTEGER_DECODER;
 
 @SuppressWarnings("serial")
 public class LongRangeBroadcastMessage extends AISMessage implements DynamicDataReport {
@@ -56,9 +57,19 @@ public class LongRangeBroadcastMessage extends AISMessage implements DynamicData
 	}
 
     @SuppressWarnings("unused")
+    public Integer getRawLongitude() {
+        return INTEGER_DECODER.apply(getBits(44, 62));
+    }
+
+    @SuppressWarnings("unused")
 	public Float getLatitude() {
         return getDecodedValue(() -> latitude, value -> latitude = value, () -> Boolean.TRUE, () -> FLOAT_DECODER.apply(getBits(62, 79)) / 600f);
 	}
+
+    @SuppressWarnings("unused")
+    public Integer getRawLatitude() {
+        return INTEGER_DECODER.apply(getBits(62, 79));
+    }
 
     /**
      * @return Knots (0-62); 63 = not available = default
@@ -68,6 +79,11 @@ public class LongRangeBroadcastMessage extends AISMessage implements DynamicData
         return Float.valueOf(getDecodedValue(() -> speed, value -> speed = value, () -> Boolean.TRUE, () -> UNSIGNED_INTEGER_DECODER.apply(getBits(79, 85))));
 	}
 
+    @SuppressWarnings("unused")
+    public Integer getRawSpeedOverGround() {
+        return UNSIGNED_INTEGER_DECODER.apply(getBits(79, 85));
+    }
+
     /**
      * @return Degrees (0-359); 511 = not available = default
      */
@@ -75,6 +91,11 @@ public class LongRangeBroadcastMessage extends AISMessage implements DynamicData
 	public Float getCourseOverGround() {
         return Float.valueOf(getDecodedValue(() -> course, value -> course = value, () -> Boolean.TRUE, () -> UNSIGNED_INTEGER_DECODER.apply(getBits(85, 94))));
 	}
+
+    @SuppressWarnings("unused")
+    public Integer getRawCourseOverGround() {
+        return UNSIGNED_INTEGER_DECODER.apply(getBits(85, 94));
+    }
 
     /**
      * @return 0 if reported position latency is less than 5 seconds; 1 if reported position latency is greater than 5 seconds = default

--- a/src/main/java/dk/tbsalling/aismessages/ais/messages/PositionReport.java
+++ b/src/main/java/dk/tbsalling/aismessages/ais/messages/PositionReport.java
@@ -75,6 +75,11 @@ public abstract class PositionReport extends AISMessage implements ExtendedDynam
 	}
 
     @SuppressWarnings("unused")
+	public Integer getRawSpeedOverGround() {
+        return UNSIGNED_INTEGER_DECODER.apply(getBits(50, 60));
+    }
+
+    @SuppressWarnings("unused")
 	public Boolean getPositionAccuracy() {
         return getDecodedValue(() -> positionAccuracy, value -> positionAccuracy = value, () -> Boolean.TRUE, () -> BOOLEAN_DECODER.apply(getBits(60, 61)));
 	}
@@ -85,14 +90,29 @@ public abstract class PositionReport extends AISMessage implements ExtendedDynam
 	}
 
     @SuppressWarnings("unused")
+    public Integer getRawLatitude() {
+        return INTEGER_DECODER.apply(getBits(89, 116));
+    }
+
+    @SuppressWarnings("unused")
 	public Float getLongitude() {
         return getDecodedValue(() -> longitude, value -> longitude = value, () -> Boolean.TRUE, () -> FLOAT_DECODER.apply(getBits(61, 89)) / 600000f);
 	}
 
     @SuppressWarnings("unused")
+    public Integer getRawLongitude() {
+        return INTEGER_DECODER.apply(getBits(61, 89));
+    }
+
+    @SuppressWarnings("unused")
 	public Float getCourseOverGround() {
         return getDecodedValue(() -> courseOverGround, value -> courseOverGround = value, () -> Boolean.TRUE, () -> UNSIGNED_FLOAT_DECODER.apply(getBits(116, 128)) / 10f);
 	}
+
+    @SuppressWarnings("unused")
+    public Integer getRawCourseOverGround() {
+        return UNSIGNED_INTEGER_DECODER.apply(getBits(116, 128));
+    }
 
     @SuppressWarnings("unused")
 	public Integer getTrueHeading() {

--- a/src/main/java/dk/tbsalling/aismessages/ais/messages/ShipAndVoyageData.java
+++ b/src/main/java/dk/tbsalling/aismessages/ais/messages/ShipAndVoyageData.java
@@ -127,6 +127,11 @@ public class ShipAndVoyageData extends AISMessage implements StaticDataReport {
 	}
 
     @SuppressWarnings("unused")
+    public Integer getRawDraught() {
+        return UNSIGNED_INTEGER_DECODER.apply(getBits(294, 302));
+    }
+
+    @SuppressWarnings("unused")
 	public String getDestination() {
         return getDecodedValue(() -> destination, value -> destination = value, () -> Boolean.TRUE, () -> STRING_DECODER.apply(getBits(302, 422)));
 	}

--- a/src/main/java/dk/tbsalling/aismessages/ais/messages/StandardClassBCSPositionReport.java
+++ b/src/main/java/dk/tbsalling/aismessages/ais/messages/StandardClassBCSPositionReport.java
@@ -30,6 +30,7 @@ import static dk.tbsalling.aismessages.ais.Decoders.BOOLEAN_DECODER;
 import static dk.tbsalling.aismessages.ais.Decoders.FLOAT_DECODER;
 import static dk.tbsalling.aismessages.ais.Decoders.UNSIGNED_FLOAT_DECODER;
 import static dk.tbsalling.aismessages.ais.Decoders.UNSIGNED_INTEGER_DECODER;
+import static dk.tbsalling.aismessages.ais.Decoders.INTEGER_DECODER;
 
 /**
  * A less detailed report than types 1-3 for vessels using Class B transmitters.
@@ -72,6 +73,11 @@ public class StandardClassBCSPositionReport extends AISMessage implements Extend
 	}
 
     @SuppressWarnings("unused")
+    public Integer getRawSpeedOverGround() {
+        return UNSIGNED_INTEGER_DECODER.apply(getBits(46, 56));
+    }
+
+    @SuppressWarnings("unused")
 	public Boolean getPositionAccurate() {
         return getDecodedValue(() -> positionAccurate, value -> positionAccurate = value, () -> Boolean.TRUE, () -> BOOLEAN_DECODER.apply(getBits(56, 57)));
 	}
@@ -82,14 +88,29 @@ public class StandardClassBCSPositionReport extends AISMessage implements Extend
 	}
 
     @SuppressWarnings("unused")
+    public Integer getRawLatitude() {
+        return INTEGER_DECODER.apply(getBits(85, 112));
+    }
+
+    @SuppressWarnings("unused")
 	public Float getLongitude() {
         return getDecodedValue(() -> longitude, value -> longitude = value, () -> Boolean.TRUE, () -> FLOAT_DECODER.apply(getBits(57, 85)) / 600000f);
 	}
 
     @SuppressWarnings("unused")
+    public Integer getRawLongitude() {
+        return INTEGER_DECODER.apply(getBits(57, 85));
+    }
+
+    @SuppressWarnings("unused")
 	public Float getCourseOverGround() {
         return getDecodedValue(() -> courseOverGround, value -> courseOverGround = value, () -> Boolean.TRUE, () -> UNSIGNED_FLOAT_DECODER.apply(getBits(112, 124)) / 10f);
 	}
+
+    @SuppressWarnings("unused")
+    public Integer getRawCourseOverGround() {
+        return UNSIGNED_INTEGER_DECODER.apply(getBits(112, 124));
+    }
 
     @SuppressWarnings("unused")
 	public Integer getTrueHeading() {

--- a/src/main/java/dk/tbsalling/aismessages/ais/messages/StandardSARAircraftPositionReport.java
+++ b/src/main/java/dk/tbsalling/aismessages/ais/messages/StandardSARAircraftPositionReport.java
@@ -25,6 +25,7 @@ import static dk.tbsalling.aismessages.ais.Decoders.BOOLEAN_DECODER;
 import static dk.tbsalling.aismessages.ais.Decoders.FLOAT_DECODER;
 import static dk.tbsalling.aismessages.ais.Decoders.UNSIGNED_FLOAT_DECODER;
 import static dk.tbsalling.aismessages.ais.Decoders.UNSIGNED_INTEGER_DECODER;
+import static dk.tbsalling.aismessages.ais.Decoders.INTEGER_DECODER;
 
 @SuppressWarnings("serial")
 public class StandardSARAircraftPositionReport extends AISMessage implements DynamicDataReport {
@@ -60,6 +61,11 @@ public class StandardSARAircraftPositionReport extends AISMessage implements Dyn
 	}
 
     @SuppressWarnings("unused")
+    public Integer getRawSpeedOverGround() {
+        return UNSIGNED_INTEGER_DECODER.apply(getBits(50, 60));
+    }
+
+    @SuppressWarnings("unused")
 	public Boolean getPositionAccurate() {
         return getDecodedValue(() -> positionAccurate, value -> positionAccurate = value, () -> Boolean.TRUE, () -> BOOLEAN_DECODER.apply(getBits(60, 61)));
 	}
@@ -70,14 +76,29 @@ public class StandardSARAircraftPositionReport extends AISMessage implements Dyn
 	}
 
     @SuppressWarnings("unused")
+    public Integer getRawLongitude() {
+        return INTEGER_DECODER.apply(getBits(61, 89));
+    }
+
+    @SuppressWarnings("unused")
     public Float getLatitude() {
         return getDecodedValue(() -> latitude, value -> latitude = value, () -> Boolean.TRUE, () -> FLOAT_DECODER.apply(getBits(89, 116)) / 600000f);
+    }
+
+    @SuppressWarnings("unused")
+    public Integer getRawLatitude() {
+        return INTEGER_DECODER.apply(getBits(89, 116));
     }
 
     @SuppressWarnings("unused")
 	public Float getCourseOverGround() {
         return getDecodedValue(() -> courseOverGround, value -> courseOverGround = value, () -> Boolean.TRUE, () -> UNSIGNED_FLOAT_DECODER.apply(getBits(116, 128)) / 10f);
 	}
+
+    @SuppressWarnings("unused")
+    public Integer getRawCourseOverGround() {
+        return UNSIGNED_INTEGER_DECODER.apply(getBits(116, 128));
+    }
 
     @SuppressWarnings("unused")
 	public Integer getSecond() {

--- a/src/test/java/dk/tbsalling/aismessages/ais/messages/LongRangeBroadcastMessageTest.java
+++ b/src/test/java/dk/tbsalling/aismessages/ais/messages/LongRangeBroadcastMessageTest.java
@@ -29,7 +29,9 @@ public class LongRangeBroadcastMessageTest {
         assertEquals(Float.valueOf(137.02333f), message.getLongitude());
         assertEquals(Float.valueOf(4.84f), message.getLatitude());
         assertEquals(Float.valueOf(57f), message.getSpeedOverGround(), 1e-5);
+        assertEquals((Integer)57, message.getRawSpeedOverGround());
         assertEquals(Float.valueOf(167f), message.getCourseOverGround(), 1e-5);
+        assertEquals((Integer)167, message.getRawCourseOverGround());
     }
 
     @Test
@@ -49,7 +51,9 @@ public class LongRangeBroadcastMessageTest {
         assertEquals(Float.valueOf(176.18167f), message.getLongitude());
         assertEquals(Float.valueOf(-37.65333f), message.getLatitude());
         assertEquals(Float.valueOf(0f), message.getSpeedOverGround(), 1e-5);
+        assertEquals((Integer)0, message.getRawSpeedOverGround());
         assertEquals(Float.valueOf(11f), message.getCourseOverGround(), 1e-5);
+        assertEquals((Integer)11, message.getRawCourseOverGround());
     }
 
 }

--- a/src/test/java/dk/tbsalling/aismessages/ais/messages/PositionReportClassAAssignedScheduleTest.java
+++ b/src/test/java/dk/tbsalling/aismessages/ais/messages/PositionReportClassAAssignedScheduleTest.java
@@ -53,8 +53,11 @@ public class PositionReportClassAAssignedScheduleTest {
         assertEquals((Float) 13.6f, message.getSpeedOverGround());
         assertTrue(message.getPositionAccuracy());
         assertEquals(Float.valueOf(37.21113f), message.getLatitude());
+        assertEquals((Integer) 22326676, message.getRawLatitude());
         assertEquals(Float.valueOf(-123.45053f), message.getLongitude());
+        assertEquals((Integer) (-74070321), message.getRawLongitude());
         assertEquals(Float.valueOf(329.7f), message.getCourseOverGround());
+        assertEquals((Integer) 3297, message.getRawCourseOverGround());
         assertEquals((Integer) 331, message.getTrueHeading());
         assertEquals((Integer) 7, message.getSecond());
         assertEquals(ManeuverIndicator.NotAvailable, message.getSpecialManeuverIndicator());

--- a/src/test/java/dk/tbsalling/aismessages/ais/messages/PositionReportClassAResponseToInterrogationTest.java
+++ b/src/test/java/dk/tbsalling/aismessages/ais/messages/PositionReportClassAResponseToInterrogationTest.java
@@ -28,10 +28,14 @@ public class PositionReportClassAResponseToInterrogationTest {
         assertEquals(NavigationStatus.UnderwayUsingEngine, message.getNavigationStatus());
         assertEquals((Integer) 0, message.getRateOfTurn());
         assertEquals((Float) 13.6f, message.getSpeedOverGround());
+        assertEquals((Integer) 136, message.getRawSpeedOverGround());
         assertTrue(message.getPositionAccuracy());
         assertEquals(Float.valueOf(37.21113f), message.getLatitude());
+        assertEquals((Integer)22326676, message.getRawLatitude());
         assertEquals(Float.valueOf(-123.45053f), message.getLongitude());
+        assertEquals((Integer)(-74070321), message.getRawLongitude());
         assertEquals(Float.valueOf(329.7f), message.getCourseOverGround());
+        assertEquals((Integer) 3297, message.getRawCourseOverGround());
         assertEquals((Integer) 331, message.getTrueHeading());
         assertEquals((Integer) 7, message.getSecond());
         assertEquals(ManeuverIndicator.NotAvailable, message.getSpecialManeuverIndicator());

--- a/src/test/java/dk/tbsalling/aismessages/ais/messages/PositionReportClassAScheduledTest.java
+++ b/src/test/java/dk/tbsalling/aismessages/ais/messages/PositionReportClassAScheduledTest.java
@@ -32,8 +32,11 @@ public class PositionReportClassAScheduledTest {
         assertEquals((Float) 7.8f, message.getSpeedOverGround());
         assertTrue(message.getPositionAccuracy());
         assertEquals(Float.valueOf(56.56692f), message.getLatitude());
+        assertEquals((Integer) 33940151, message.getRawLatitude());
         assertEquals(Float.valueOf(11.071096f), message.getLongitude());
+        assertEquals((Integer) 6642658, message.getRawLongitude());
         assertEquals(Float.valueOf(189.7f), message.getCourseOverGround());
+        assertEquals((Integer) 1897, message.getRawCourseOverGround());
         assertEquals((Integer) 46, message.getSecond());
         assertEquals((Integer) 186, message.getTrueHeading());
         assertEquals(ManeuverIndicator.NotAvailable, message.getSpecialManeuverIndicator());

--- a/src/test/java/dk/tbsalling/aismessages/ais/messages/ShipAndVoyageDataTest.java
+++ b/src/test/java/dk/tbsalling/aismessages/ais/messages/ShipAndVoyageDataTest.java
@@ -40,6 +40,7 @@ public class ShipAndVoyageDataTest {
         assertEquals(Integer.valueOf(14), message.getToPort());
         assertEquals(PositionFixingDevice.Gps, message.getPositionFixingDevice());
         assertEquals(Float.valueOf("8.3"), message.getDraught());
+        assertEquals((Integer) 83 , message.getRawDraught());
         assertEquals("06-03 19:00", message.getEta());
         assertEquals("SFO 70", message.getDestination());
         assertFalse(message.getDataTerminalReady());

--- a/src/test/java/dk/tbsalling/aismessages/ais/messages/StandardClassBCSPositionReportTest.java
+++ b/src/test/java/dk/tbsalling/aismessages/ais/messages/StandardClassBCSPositionReportTest.java
@@ -26,10 +26,14 @@ public class StandardClassBCSPositionReportTest {
         assertEquals(MMSI.valueOf(367430530), message.getSourceMmsi());
         assertEquals("00000000", message.getRegionalReserved1());
         assertEquals((Float) 0.0f, message.getSpeedOverGround());
+        assertEquals((Integer) 0, message.getRawSpeedOverGround());
         assertFalse(message.getPositionAccurate());
         assertEquals(Float.valueOf(37.785034f), message.getLatitude());
+        assertEquals((Integer)22671021, message.getRawLatitude());
         assertEquals(Float.valueOf(-122.26732f), message.getLongitude());
+        assertEquals((Integer)(-73360392), message.getRawLongitude());
         assertEquals(Float.valueOf(0.0f), message.getCourseOverGround());
+        assertEquals((Integer) 0, message.getRawCourseOverGround());
         assertEquals((Integer) 511, message.getTrueHeading());
         assertEquals((Integer) 55, message.getSecond());
         assertEquals("00", message.getRegionalReserved2());


### PR DESCRIPTION
Add methods to retrieve the unparsed integer values of Latitude, Longitude, Speed over ground , course over ground and draught.

Float is absolutely the right default here, but for storing the raw data or avoiding floating point errors it is not ideal. These methods give access to the values directly from the AIS message.

I used this naming scheme to pollute auto-completion as little as possible, and it is in line with `getRawMessages`.