### PR TITLE
Add methods to retrieve ETA month/day/hour/minute

### DIFF
--- a/src/main/java/dk/tbsalling/aismessages/ais/Decoders.java
+++ b/src/main/java/dk/tbsalling/aismessages/ais/Decoders.java
@@ -121,6 +121,7 @@ public class Decoders {
 
     public static final Function<String, Float> UNSIGNED_FLOAT_DECODER = bitString -> Float.valueOf(UNSIGNED_INTEGER_DECODER.apply(bitString));
 
+    @Deprecated
     public static final Function<String, String> TIME_DECODER = bitString -> {
         Integer month = UNSIGNED_INTEGER_DECODER.apply(bitString.substring(0, 4));
         Integer day = UNSIGNED_INTEGER_DECODER.apply(bitString.substring(4, 9));

--- a/src/main/java/dk/tbsalling/aismessages/ais/messages/ShipAndVoyageData.java
+++ b/src/main/java/dk/tbsalling/aismessages/ais/messages/ShipAndVoyageData.java
@@ -27,7 +27,6 @@ import dk.tbsalling.aismessages.nmea.messages.NMEAMessage;
 
 import static dk.tbsalling.aismessages.ais.Decoders.BOOLEAN_DECODER;
 import static dk.tbsalling.aismessages.ais.Decoders.STRING_DECODER;
-import static dk.tbsalling.aismessages.ais.Decoders.TIME_DECODER;
 import static dk.tbsalling.aismessages.ais.Decoders.UNSIGNED_FLOAT_DECODER;
 import static dk.tbsalling.aismessages.ais.Decoders.UNSIGNED_INTEGER_DECODER;
 
@@ -116,9 +115,33 @@ public class ShipAndVoyageData extends AISMessage implements StaticDataReport {
         return getDecodedValue(() -> positionFixingDevice, value -> positionFixingDevice = value, () -> Boolean.TRUE, () -> PositionFixingDevice.fromInteger(UNSIGNED_INTEGER_DECODER.apply(getBits(270, 274))));
 	}
 
+	/** @return The UTC ETA Month (1-12) 0 = not available. */
+    @SuppressWarnings("unused")
+    public Integer getEtaMonth() {
+        return getDecodedValue(() -> etaMonth, value -> etaMonth = value, () -> Boolean.TRUE, () -> UNSIGNED_INTEGER_DECODER.apply(getBits(274, 278)));
+    }
+
+    /** @return The UTC ETA Day (1-31) 0 = not available. */
+    @SuppressWarnings("unused")
+    public Integer getEtaDay() {
+        return getDecodedValue(() -> etaDay, value -> etaDay = value, () -> Boolean.TRUE, () -> UNSIGNED_INTEGER_DECODER.apply(getBits(278, 283)));
+    }
+
+    /** @return The UTC ETA Hour (0-23) 24 = not available. */
+    @SuppressWarnings("unused")
+    public Integer getEtaHour() {
+        return getDecodedValue(() -> etaHour, value -> etaHour = value, () -> Boolean.TRUE, () -> UNSIGNED_INTEGER_DECODER.apply(getBits(283, 288)));
+    }
+
+    /** @return The UTC ETA Minute (0-59) 60 = not available. */
+    @SuppressWarnings("unused")
+    public Integer getEtaMinute() {
+        return getDecodedValue(() -> etaMinute, value -> etaMinute = value, () -> Boolean.TRUE, () -> UNSIGNED_INTEGER_DECODER.apply(getBits(288, 294)));
+    }
+
     @SuppressWarnings("unused")
 	public String getEta() {
-        return getDecodedValue(() -> eta, value -> eta = value, () -> Boolean.TRUE, () -> TIME_DECODER.apply(getBits(274, 294)));
+        return String.format("%02d-%02d %02d:%02d", this.getEtaDay(), this.getEtaMonth(), this.getEtaHour(), this.getEtaMinute());
 	}
 
     @SuppressWarnings("unused")
@@ -165,7 +188,10 @@ public class ShipAndVoyageData extends AISMessage implements StaticDataReport {
     private transient Integer toStarboard;
     private transient Integer toPort;
     private transient PositionFixingDevice positionFixingDevice;
-    private transient String eta;
+    private transient Integer etaMonth;
+    private transient Integer etaDay;
+    private transient Integer etaHour;
+    private transient Integer etaMinute;
     private transient Float draught;
     private transient String destination;
     private transient Boolean dataTerminalReady;

--- a/src/test/java/dk/tbsalling/aismessages/ais/messages/ShipAndVoyageDataTest.java
+++ b/src/test/java/dk/tbsalling/aismessages/ais/messages/ShipAndVoyageDataTest.java
@@ -41,6 +41,10 @@ public class ShipAndVoyageDataTest {
         assertEquals(PositionFixingDevice.Gps, message.getPositionFixingDevice());
         assertEquals(Float.valueOf("8.3"), message.getDraught());
         assertEquals("06-03 19:00", message.getEta());
+        assertEquals((Integer) 3, message.getEtaMonth());
+        assertEquals((Integer) 6, message.getEtaDay());
+        assertEquals((Integer) 19, message.getEtaHour());
+        assertEquals((Integer) 0, message.getEtaMinute());
         assertEquals("SFO 70", message.getDestination());
         assertFalse(message.getDataTerminalReady());
     }
@@ -69,6 +73,10 @@ public class ShipAndVoyageDataTest {
         assertNull(message.getPositionFixingDevice());
         assertEquals(Float.valueOf("0"), message.getDraught());
         assertEquals("14-05 20:10", message.getEta());
+        assertEquals((Integer) 5, message.getEtaMonth());
+        assertEquals((Integer) 14, message.getEtaDay());
+        assertEquals((Integer) 20, message.getEtaHour());
+        assertEquals((Integer) 10, message.getEtaMinute());
         assertEquals("", message.getDestination());
         assertFalse(message.getDataTerminalReady());
     }


### PR DESCRIPTION
Currently the ETA is only available as a string.
This causes us to have to parse that string to get the numeric values, which feels unnecessary as the AIS message directly contains the numeric values.

I have not cached the string in this implementation (instead caching the integers), if desirable I can add that

