### PR TITLE
Handle AISHub message 5 with 426 bits

### DIFF
--- a/src/main/java/dk/tbsalling/aismessages/ais/messages/ShipAndVoyageData.java
+++ b/src/main/java/dk/tbsalling/aismessages/ais/messages/ShipAndVoyageData.java
@@ -53,8 +53,8 @@ public class ShipAndVoyageData extends AISMessage implements StaticDataReport {
             throw new UnsupportedMessageType(messageType.getCode());
         }
         final int numberOfBits = getNumberOfBits();
-        if (numberOfBits != 424 && numberOfBits != 422) {
-            throw new InvalidMessage("Message of type " + messageType + " expected to be 422 or 424 bits long; not " + numberOfBits);
+        if (numberOfBits != 424 && numberOfBits != 422 && numberOfBits != 426) {
+            throw new InvalidMessage("Message of type " + messageType + " expected to be 422, 424 or 426 bits long; not " + numberOfBits);
         }
     }
 


### PR DESCRIPTION
"The most common error observed in the wild on AISHub is reporting a pad 2 bits too small, making the message look like it is 2 bits longer than it actually is. This seems for some reason to be most common on Type 5 messages, which then decode as 426 bits rather than 424."

Source: https://gpsd.gitlab.io/gpsd/AIVDM.html#_interaction_with_aivdm_padding